### PR TITLE
Updated documentation to make more beginner friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ mkdir build && cd build
 cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 ninja
 sudo ninja install
+sudo ldconfig
 ```
 
 Pull-requests are very welcome! (Code should be valid C++14, use 4 spaces for indentation)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ On Debian-based Linux systems, all dependencies can be installed from the packag
 ```bash
 sudo apt install cmake ninja-build qtbase5-dev libqt5opengl5-dev libkf5configwidgets-dev \
                  libopencv-dev libavcodec-dev libavformat-dev libswscale-dev \
-                 pybind11-dev python3-dev python3-numpy
+                 pybind11-dev python3-dev python3-numpy build-essential
 ```
 The software can then be built:
 ```bash


### PR DESCRIPTION
As described in the individual commits, I added `build-essential` to the apt command and `sudo ldconfig` as was required to build out-of-the-box on Ubuntu 20.04.3 and Debian 11 installs. 

Without `sudo ldconfig` the error:
```
pomidaq: error while loading shared libraries: libminiscope.so.0: cannot open shared object file: No such file or directory
```
occurred on runtime after successful build and installation.
Hopefully this makes easier for beginners to get started.
